### PR TITLE
Fix (sometimes) failing test.

### DIFF
--- a/t/ack-1.t
+++ b/t/ack-1.t
@@ -47,7 +47,7 @@ DASH_F: {
 
 
 DASH_G: {
-    my $regex = '(?<!nota)Makefile';
+    my $regex = '\bMakefile\b';
     my @files = qw( t/ );
     my @args = ( '-1', '-g', $regex );
     my @results = run_ack( @args, @files );


### PR DESCRIPTION
This fix makes sure that ack-1.t won't match "notaMakefile" instead of either "Makefile" or "Makefile.PL" by adding a negative lookbehind assertion.
