### PR TITLE
Issue 150

### DIFF
--- a/ack
+++ b/ack
@@ -1107,7 +1107,7 @@ so would require reading in the entire file at a time.
 If you want to see lines near your match, use the C<--A>, C<--B>
 and C<--C> switches for displaying context.
 
-=head2 Why is ack telling me I have an invalid option wFen searching for C<+foo>?
+=head2 Why is ack telling me I have an invalid option when searching for C<+foo>?
 
 ack treats command line options beginning with C<+> or C<-> as options; if you
 would like to search for these, you may prefix your search term with C<--> or


### PR DESCRIPTION
Fixes everything for #150, as described in petdance/ack#233, except:
- --help-types is already described in man and help
- --invert-file-match is no longer supported
- --env doesn't need to be documented since --noenv is, IMHO

Also fixed a reference to -a and a typo.

The first FAQ in the man page leans heavily on the -a and -u options, and thus should be rewritten. But I didn't get to that :wink:
