### PR TITLE
Add --type=rust

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -226,6 +226,9 @@ sub _options_block {
 --type-add=ruby:is:Rakefile
 --type-add=ruby:firstlinematch:/#!.*\bruby/
 
+# Rust http://www.rust-lang.org/
+--type-add=rust:ext:rs
+
 # Scala http://www.scala-lang.org/
 --type-add=scala:ext:scala
 

--- a/t/ack-filetypes.t
+++ b/t/ack-filetypes.t
@@ -46,6 +46,7 @@ plone
 python
 rake
 ruby
+rust
 scala
 scheme
 shell


### PR DESCRIPTION
I read somewhere that you're not adding any new languages to ack<2, so here's a Rust patch for ack2!
