### PR TITLE
Don't colorize groups if given --nocolor

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -948,28 +948,30 @@ sub print_line_with_options {
         }
     }
     else {
-        my @capture_indices = get_capture_indices();
-        if( @capture_indices ) {
-            my $offset = 0; # additional offset for when we add stuff
+        if ( $color ) {
+            my @capture_indices = get_capture_indices();
+            if( @capture_indices ) {
+                my $offset = 0; # additional offset for when we add stuff
 
-            foreach my $index_pair ( @capture_indices ) {
-                my ( $match_start, $match_end ) = @{$index_pair};
+                foreach my $index_pair ( @capture_indices ) {
+                    my ( $match_start, $match_end ) = @{$index_pair};
 
-                my $substring = substr( $line,
-                    $offset + $match_start, $match_end - $match_start );
-                my $substitution = Term::ANSIColor::colored( $substring,
-                    $ENV{ACK_COLOR_MATCH} );
+                    my $substring = substr( $line,
+                        $offset + $match_start, $match_end - $match_start );
+                    my $substitution = Term::ANSIColor::colored( $substring,
+                        $ENV{ACK_COLOR_MATCH} );
 
-                substr( $line, $offset + $match_start,
-                    $match_end - $match_start, $substitution );
+                    substr( $line, $offset + $match_start,
+                        $match_end - $match_start, $substitution );
 
-                $offset += length( $substitution ) - length( $substring );
+                    $offset += length( $substitution ) - length( $substring );
+                }
             }
-        }
-        elsif( $color ) {
-            # XXX I know $& is a no-no; fix it later
-            if($line  =~ s/$re/Term::ANSIColor::colored($&, $ENV{ACK_COLOR_MATCH})/ge) {
-                $line .= "\033[0m\033[K";
+            else {
+                # XXX I know $& is a no-no; fix it later
+                if($line  =~ s/$re/Term::ANSIColor::colored($&, $ENV{ACK_COLOR_MATCH})/ge) {
+                    $line .= "\033[0m\033[K";
+                }
             }
         }
 

--- a/t/ack-color.t
+++ b/t/ack-color.t
@@ -27,7 +27,7 @@ NORMAL_COLOR: {
 
 MATCH_WITH_BACKREF: {
     my @files = qw( t/text/boy-named-sue.txt );
-    my @args = ( '(called).*\1' );
+    my @args = qw( (called).*\1 --color );
     my @results = run_ack( @args, @files );
 
     is( @results, 1, 'backref pattern matches once' );

--- a/t/ack-interactive.t
+++ b/t/ack-interactive.t
@@ -14,7 +14,7 @@ if ( not has_io_pty() ) {
     exit(0);
 }
 
-plan tests => 5;
+plan tests => 6;
 
 prep_environment();
 
@@ -98,6 +98,23 @@ INTERACTIVE_GROUPING_COLOR: {
 
 INTERACTIVE_SINGLE_TARGET: {
     my @args  = qw( Sue --nocolor );
+    my @files = qw( t/text/boy-named-sue.txt );
+
+    my $output = run_ack_interactive(@args, @files);
+
+    is $output, <<'END_OUTPUT';
+Was before he left, he went and named me Sue.
+I tell ya, life ain't easy for a boy named Sue.
+Sat the dirty, mangy dog that named me Sue.
+And I said: "My name is Sue! How do you do! Now you gonna die!"
+Cause I'm the son-of-a-bitch that named you Sue."
+Bill or George! Anything but Sue! I still hate that name!
+    -- "A Boy Named Sue", Johnny Cash
+END_OUTPUT
+}
+
+INTERACTIVE_NOCOLOR_REGEXP_CAPTURE: {
+    my @args = qw( (Sue) --nocolor );
     my @files = qw( t/text/boy-named-sue.txt );
 
     my $output = run_ack_interactive(@args, @files);


### PR DESCRIPTION
ack was colorizing captured groups even if --nocolor was given.  Fixed
this by moving up the "if ( $color )" guard to cover all the
colorizing bits in print_line_with_options.  I also added a test to
t/ack-interactive.t to cover this bug.

ack-color.t had a test that was only passing because of this bug where
captured groups would always be colored; that test was fixed by just
adding --color to its args.
