### PR TITLE
Tiny optimization (removing regex in Basic.pm, next_text)

### DIFF
--- a/Basic.pm
+++ b/Basic.pm
@@ -50,9 +50,7 @@ Returns the name of the resource.
 =cut
 
 sub name {
-    my $self = shift;
-
-    return $self->{filename};
+    return $_[0]->{filename};
 }
 
 
@@ -127,7 +125,13 @@ the text.  This basically emulates a call to C<< <$fh> >>.
 sub next_text {
     if ( defined ($_ = readline $_[0]->{fh}) ) {
         $. = ++$_[0]->{line};
-        s/[\r\n]+$//; # chomp may not handle this
+
+        my $line_end = substr $_, -1;
+        while ($line_end eq "\n" || $line_end eq "\r") {
+            chop;
+            $line_end = substr $_, -1;
+        }
+
         $_ .= "\n"; # add back newline (XXX make it native)
         return 1;
     }


### PR DESCRIPTION
If we chop off the trailing [\r\n] in a while loop and a `substr`, it's roughly 3x faster (as far as I can tell) than doing an `s/[\r\n]+//`, since it doesn't have to copy the string. It's not much, but it should help a bit in large directories.
