### PR TITLE
Add support for fish shell language

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -169,6 +169,9 @@ sub _options_block {
 # Erlang http://www.erlang.org/
 --type-add=erlang:ext:erl,hrl
 
+# Fish http://fishshell.com/
+--type-add=fish:ext:fish
+
 # Fortran http://en.wikipedia.org/wiki/Fortran
 --type-add=fortran:ext:f,f77,f90,f95,f03,for,ftn,fpp
 

--- a/t/ack-filetypes.t
+++ b/t/ack-filetypes.t
@@ -24,6 +24,7 @@ css
 delphi
 elisp
 erlang
+fish
 fortran
 go
 groovy


### PR DESCRIPTION
Currently ack doesn't recognize fish shell. This pull request adds it. Also, see petdance/ack#188 and petdance/ack#203, for other pull requests for that.

I think it should have separate language, because it doesn't use syntax of bash, but its own syntax designed to be user friendlier.
