### PR TITLE
Fix for Win32 require in ConfigFinder (issue #231)

### DIFF
--- a/ConfigFinder.pm
+++ b/ConfigFinder.pm
@@ -40,11 +40,7 @@ use App::Ack ();
 use Cwd 3.00 ();
 use File::Spec 3.00;
 
-BEGIN {
-    if ($App::Ack::is_windows) {
-        require Win32;
-    }
-}
+use if ($^O =~ /MSWin32/ ? 1 : 0), "Win32";
 
 =head1 METHODS
 


### PR DESCRIPTION
This doesn't fix the Windows installation problem, but does get around
the circular dependency noted by @damil.
