### PR TITLE
Ignore Node modules

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -80,6 +80,8 @@ sub _options_block {
 # Perl Devel::Cover module's output directory
 --ignore-directory=is:cover_db
 
+# Node modules
+--ignore-directory=node_modules
 
 
 # Files to ignore


### PR DESCRIPTION
In projects with lots of modules installed using `npm install` in code directory directly, `ack` gives lots of noise for module dependencies (because `npm install` installs directly in code directory - in `node_modules` directory). I don't think it should search in dependencies, only in code itself.
