### PR TITLE
Display petdance/ack2's build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ack 2.0
 
-[![Build Status](https://travis-ci.org/lenniboy/ack2.png?branch=dev)](https://travis-ci.org/lenniboy/ack2)
+[![Build Status](https://travis-ci.org/petdance/ack2.png?branch=dev)](https://travis-ci.org/petdance/ack2)
 
 ack 2.0 is a text searching utility optimized for searching trees of source code.
 


### PR DESCRIPTION
The README currently shows my fork's build status. This PR fixes this.
