### PR TITLE
Ignore CMake cache

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -83,6 +83,9 @@ sub _options_block {
 # Node modules created by npm
 --ignore-directory=is:node_modules
 
+# CMake cache
+--ignore-directory=is:CMakeFiles
+
 # Files to ignore
 # Backup files
 --ignore-file=ext:bak


### PR DESCRIPTION
CMakeFiles directories are managed by CMake, contain nothing interesting.
Ack finds undesirable references to real files in automatically generated Makefiles.
Ignore by default.
