### PR TITLE
Changing standard input detection from fstat to istty

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -46,7 +46,7 @@ use File::Spec 1.00015 ();
 BEGIN {
     # These have to be checked before any filehandle diddling.
     $output_to_pipe  = not -t *STDOUT;
-    $is_filter_mode = -p STDIN;
+    $is_filter_mode = not -t *STDIN;
 
     $is_cygwin       = ($^O eq 'cygwin');
     $is_windows      = ($^O =~ /MSWin32/);


### PR DESCRIPTION
## `-t` not supported in MSYS
### Problem

`-t` isn't supported in MSYS

This is a problem because
- it's useful to pipe input to `ack` with `echo test | ack test`
- MSYS is sometimes used instead of Cygwin as a pre-configured `make` environment, f.e. by devkitPro
- `ack` is useful for make because it can highlight errors with `make -r | ack --passthru error`
## `-t` not detecting `S_ISREG`

`-t` doesn't detect the `fstat` mode `S_ISREG`

This is a problem because
- it's useful to redirect input to `ack` with `ack test < input.txt`
## Test

The output from

```
echo test > input.txt

perl -e 'print "" . (-p STDIN) ? 1 : 0 . "\n"'
echo test | perl -e 'print "" . (-p STDIN) ? 1 : 0 . "\n"'
cat input.txt | perl -e 'print "" . (-p STDIN) ? 1 : 0 . "\n"'
perl -e 'print "" . (-p STDIN) ? 1 : 0 . "\n"' < input.txt

perl -e 'print "" . (not -t STDIN) ? 1 : 0 . "\n"'
echo test | perl -e 'print "" . (not -t STDIN) ? 1 : 0 . "\n"'
cat input.txt | perl -e 'print "" . (not -t STDIN) ? 1 : 0 . "\n"'
perl -e 'print "" . (not -t STDIN) ? 1 : 0 . "\n"' < input.txt
```

is

```
uname -a
Linux ubuntu 3.8.0-23-generic #34-Ubuntu SMP Wed May 29 20:22:58 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
perl --version
This is perl 5, version 14, subversion 2 (v5.14.2) built for x86_64-linux-gnu-thread-multi
0
1
1
0


0
1
1
1

uname -a
CYGWIN_NT-6.1-WOW64 pc 1.7.18(0.263/5/3) 2013-04-19 10:39 i686 Cygwin
perl --version
This is perl 5, version 14, subversion 2 (v5.14.2) built for cygwin-thread-multi-64int
0
1
1
0

0
1
1
1

uname -a
MSYS_NT-6.1 PC 1.0.18(0.48/3/2) 2012-11-21 22:34 i686 Msys
perl --version
This is perl, v5.8.8 built for msys-64int
0
0
0
0

0
1
1
1
```
## Communication at github.com compared to groups.google.com

> communicate this message to https://groups.google.com/forum/#!forum/ack-users
> Because that's how we do it

What's the reason for communicating this message to groups.google.com in addition to github.com?

I.o.w. what's the benefit of communication at groups.google.com compared to github.com?
