### PR TITLE
Suggest --dump when disallowed options are found

### DIFF
--- a/ConfigLoader.pm
+++ b/ConfigLoader.pm
@@ -199,6 +199,7 @@ sub get_arg_spec {
     my $dash_a_explanation = <<EOT;
 This is because we now have -k/--known-types which makes it only select files
 of known types, rather than any text file (which is the behavior of ack 1.x).
+You may have options in a .ackrc - try using the --dump flag.
 EOT
 
 =for Adding-Options


### PR DESCRIPTION
Improved message when rejecting old options, because the options can
be hidden (unexpectedly) in a user or project .ackrc file.
