### PR TITLE
Added filter groups to speed up "is:" and "ext:"

### DIFF
--- a/Collection.pm
+++ b/Collection.pm
@@ -1,0 +1,74 @@
+package App::Ack::Filter::Collection;
+
+use strict;
+use warnings;
+use base 'App::Ack::Filter';
+
+use File::Spec 3.00 ();
+
+sub new {
+    my ( $class ) = @_;
+
+    return bless {
+        groups => {},
+        ungrouped => [],
+    }, $class;
+}
+
+sub filter {
+    my ( $self, $resource ) = @_;
+
+    for my $group (values %{$self->{'groups'}}) {
+        if ($group->filter($resource)) {
+            return 1;
+        }
+    }
+
+    for my $filter (@{$self->{'ungrouped'}}) {
+        if ($filter->filter($resource)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+sub add {
+    my ( $self, $filter ) = @_;
+
+    if (exists $filter->{'groupname'}) {
+        my $groups = $self->{'groups'};
+        my $group_name = $filter->{'groupname'};
+
+        my $group;
+        if (exists $groups->{$group_name}) {
+            $group = $groups->{$group_name};
+        }
+        else {
+            $group = $groups->{$group_name} = $filter->create_group();
+        }
+
+        $group->add($filter);
+    }
+    else {
+        push $self->{'ungrouped'}, $filter;
+    }
+
+    return;
+}
+
+sub inspect {
+    my ( $self ) = @_;
+
+    return ref($self) . " - $self";
+}
+
+sub to_string {
+    my ( $self ) = @_;
+
+    my $ungrouped = $self->{'ungrouped'};
+
+    return join(', ', map { "($_)" } @{$ungrouped});
+}
+
+1;

--- a/Extension.pm
+++ b/Extension.pm
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 use base 'App::Ack::Filter';
 
+use App::Ack::Filter::ExtensionGroup;
+
 sub new {
     my ( $class, @extensions ) = @_;
 
@@ -13,7 +15,12 @@ sub new {
     return bless {
         extensions => \@extensions,
         regex      => $re,
+        groupname  => 'ExtensionGroup',
     }, $class;
+}
+
+sub create_group {
+    return App::Ack::Filter::ExtensionGroup->new();
 }
 
 sub filter {

--- a/ExtensionGroup.pm
+++ b/ExtensionGroup.pm
@@ -1,0 +1,52 @@
+package App::Ack::Filter::ExtensionGroup;
+
+use strict;
+use warnings;
+use base 'App::Ack::Filter';
+
+use File::Spec 3.00 ();
+
+sub new {
+    my ( $class ) = @_;
+
+    return bless {
+        data => {},
+    }, $class;
+}
+
+sub add {
+    my ( $self, $filter ) = @_;
+
+    my $data = $self->{'data'};
+    my $extensions = $filter->{'extensions'};
+
+    foreach my $ext (@{$extensions}) {
+        $data->{lc $ext} = 1;
+    }
+}
+
+sub filter {
+    my ( $self, $resource ) = @_;
+
+    if ($resource->name =~ /[.]([^.]*)$/) {
+        return exists $self->{'data'}->{lc $1};
+    }
+
+    return 0;
+}
+
+sub inspect {
+    my ( $self ) = @_;
+
+    return ref($self) . " - $self";
+}
+
+sub to_string {
+    my ( $self ) = @_;
+
+    my $data = $self->{'data'};
+
+    return join(' ', map { ".$_" } (keys $data));
+}
+
+1;

--- a/Is.pm
+++ b/Is.pm
@@ -5,13 +5,19 @@ use warnings;
 use base 'App::Ack::Filter';
 
 use File::Spec 3.00 ();
+use App::Ack::Filter::IsGroup;
 
 sub new {
     my ( $class, $filename ) = @_;
 
     return bless {
         filename => $filename,
+        groupname => 'IsGroup',
     }, $class;
+}
+
+sub create_group {
+    return App::Ack::Filter::IsGroup->new();
 }
 
 sub filter {

--- a/IsGroup.pm
+++ b/IsGroup.pm
@@ -1,0 +1,49 @@
+package App::Ack::Filter::IsGroup;
+
+use strict;
+use warnings;
+use base 'App::Ack::Filter';
+
+use File::Spec 3.00 ();
+
+sub new {
+    my ( $class ) = @_;
+
+    return bless {
+        data => {},
+    }, $class;
+}
+
+sub add {
+    my ( $self, $filter ) = @_;
+
+    my $data = $self->{'data'};
+    my $filename = $filter->{'filename'};
+
+    $data->{$filename} = 1;
+}
+
+sub filter {
+    my ( $self, $resource ) = @_;
+
+    my $data = $self->{'data'};
+    my $base = (File::Spec->splitpath($resource->name))[2];
+
+    return exists $data->{$base};
+}
+
+sub inspect {
+    my ( $self ) = @_;
+
+    return ref($self) . " - $self";
+}
+
+sub to_string {
+    my ( $self ) = @_;
+
+    my $data = $self->{'data'};
+
+    return join(' ', map { "$_" } (keys $data));
+}
+
+1;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,6 +29,9 @@ my %parms = (
         'Match.pm'          => '$(INST_LIBDIR)/App/Ack/Filter/Match.pm',
         'Default.pm'        => '$(INST_LIBDIR)/App/Ack/Filter/Default.pm',
         'Inverse.pm'        => '$(INST_LIBDIR)/App/Ack/Filter/Inverse.pm',
+        'Collection.pm'     => '$(INST_LIBDIR)/App/Ack/Filter/Collection.pm',
+        'IsGroup.pm'        => '$(INST_LIBDIR)/App/Ack/Filter/IsGroup.pm',
+        'ExtensionGroup.pm' => '$(INST_LIBDIR)/App/Ack/Filter/ExtensionGroup.pm',
     },
     EXE_FILES               => [ 'ack' ],
 
@@ -99,7 +102,10 @@ IS_FILTER_PM      = Is.pm
 MATCH_FILTER_PM   = Match.pm
 DEFAULT_FILTER_PM = Default.pm
 INVERSE_FILTER_PM = Inverse.pm
-ALL_PM            = $(ACK_PM) $(RESOURCE_PM) $(RESOURCES_PM) $(BASIC_PM) $(FILTER_PM) $(EXT_FILTER_PM) $(FIRST_FILTER_PM) $(IS_FILTER_PM) $(MATCH_FILTER_PM) $(DEFAULT_FILTER_PM) $(INVERSE_FILTER_PM) $(CONFIG_FINDER_PM) $(CONFIG_LOADER_PM) $(CONFIG_DEFAULT_PM)
+COLLECT_FILTER_PM = Collection.pm
+ISGRP_FILTER_PM   = IsGroup.pm
+EXTGRP_FILTER_PM  = ExtensionGroup.pm
+ALL_PM            = $(ACK_PM) $(RESOURCE_PM) $(RESOURCES_PM) $(BASIC_PM) $(FILTER_PM) $(EXT_FILTER_PM) $(FIRST_FILTER_PM) $(IS_FILTER_PM) $(MATCH_FILTER_PM) $(DEFAULT_FILTER_PM) $(INVERSE_FILTER_PM) $(COLLECT_FILTER_PM) $(ISGRP_FILTER_PM) $(EXTGRP_FILTER_PM) $(CONFIG_FINDER_PM) $(CONFIG_LOADER_PM) $(CONFIG_DEFAULT_PM)
 
 TEST_VERBOSE=0
 TEST_FILES=t/*.t t/lib/*.t


### PR DESCRIPTION
Adds an Ack::Filter::Collection class that can contain filters and
internally sort them into groups. The groups can then be optimized
for faster filtering.

In this patch, `is` and `ext` filters are grouped and replaced by a fast
hash lookup. This leads to improved performance when many such filters
are active, like when using the `--known` command line option.

Only `is:` and `ext:` filters are affected and usually there aren't enough of
them active for these changes to make a difference, but for `--known` the
speedup is quite significant:

```
$ make ack-standalone && dev/timings.pl --ack 1.96 --ack 2.08 --times 5
make: `ack-standalone' is up to date.
                                          |   1.96 |   2.08 |   HEAD
--------------------------------------------------------------------
           ack foo /home/sth/work/devices |   0.42 |   1.26 |   1.26
      ack foo --cc /home/sth/work/devices |   0.11 |   0.26 |   0.26
    ack foo --rust /home/sth/work/devices |    x_x |   0.26 |   0.26
   ack foo --known /home/sth/work/devices |   0.41 |   1.32 |   0.89
            ack -f /home/sth/work/devices |   0.11 |   0.31 |   0.32
       ack -f --cc /home/sth/work/devices |   0.11 |   0.27 |   0.27
     ack -f --rust /home/sth/work/devices |    x_x |   0.26 |   0.26
    ack -f --known /home/sth/work/devices |   0.11 |   0.80 |   0.38
        ack foo -l /home/sth/work/devices |   0.48 |   0.56 |   0.54
   ack foo -l --cc /home/sth/work/devices |   0.11 |   0.26 |   0.26
 ack foo -l --rust /home/sth/work/devices |    x_x |   0.26 |   0.26
ack foo -l --known /home/sth/work/devices |   0.47 |   0.92 |   0.50
        ack foo -c /home/sth/work/devices |   0.61 |   0.59 |   0.59
   ack foo -c --cc /home/sth/work/devices |   0.11 |   0.26 |   0.26
 ack foo -c --rust /home/sth/work/devices |    x_x |   0.26 |   0.26
ack foo -c --known /home/sth/work/devices |   0.61 |   0.95 |   0.54
```

The tests also all pass.
