### PR TITLE
Corrected $^O name for *MS*Win32.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,7 +47,7 @@ my %parms = (
         'Test::Harness'     => '2.50', # Something reasonably newish
         'Test::More'        => '0.98', # For subtest()
         'Text::ParseWords'  => '3.1',
-        ( $^O eq 'Win32' ? ('Win32::ShellQuote' => '0.002001') : () ),
+        ( $^O eq 'MSWin32' ? ('Win32::ShellQuote' => '0.002001') : () ),
     },
     MAN3PODS            => {}, # no need for man pages for any of the .pm files
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },


### PR DESCRIPTION
This was what made my Windows unit test fail.
