### PR TITLE
fix syntax of code in #375 to work on older perls

### DIFF
--- a/Collection.pm
+++ b/Collection.pm
@@ -51,7 +51,7 @@ sub add {
         $group->add($filter);
     }
     else {
-        push $self->{'ungrouped'}, $filter;
+        push @{$self->{'ungrouped'}}, $filter;
     }
 
     return;

--- a/ExtensionGroup.pm
+++ b/ExtensionGroup.pm
@@ -46,7 +46,7 @@ sub to_string {
 
     my $data = $self->{'data'};
 
-    return join(' ', map { ".$_" } (keys $data));
+    return join(' ', map { ".$_" } (keys %$data));
 }
 
 1;

--- a/IsGroup.pm
+++ b/IsGroup.pm
@@ -43,7 +43,7 @@ sub to_string {
 
     my $data = $self->{'data'};
 
-    return join(' ', map { "$_" } (keys $data));
+    return join(' ', map { "$_" } (keys %$data));
 }
 
 1;


### PR DESCRIPTION
#375 uses `push` and `keys` on scalars directly instead of dereffing, which breaks on older perls.
