### PR TITLE
skip file permission test if program remains readable (for cygwin)

### DIFF
--- a/t/file-permission.t
+++ b/t/file-permission.t
@@ -32,6 +32,7 @@ sub o { return sprintf '%o', shift }
 
 SKIP: {
     skip q{Unable to modify test program's permissions}, NTESTS if $old_mode eq $new_mode;
+    skip q{program readable despite permission changes}, NTESTS if -r $program;
 
     isnt( o($new_mode), o($old_mode), "chmodded $program to be unreadable" );
 


### PR DESCRIPTION
On Cygwin files can be readable to users even when their permissions are
set to disallow any reading. Currently i suspect this is due to Win32
admin user privileges trumping cygwin restrictions. As such, a skip is the
best fix here.
