### PR TITLE
Fix issue #326 ("flags --column and --context together produce an error")

### DIFF
--- a/ack
+++ b/ack
@@ -495,7 +495,7 @@ sub print_line_with_options {
             push @line_parts, $filename, $line_no;
         }
 
-        if( $print_column ) {
+        if( $print_column && $separator eq ':' ) {
             push @line_parts, get_match_column();
         }
     }

--- a/t/context.t
+++ b/t/context.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 30;
+use Test::More tests => 32;
 use File::Next (); # for reslash function
 
 use lib 't';
@@ -306,4 +306,53 @@ EOF
     my @args = ( '--group', '-B1', '--sort-files', $regex );
 
     ack_lists_match( [ @args, @files ], \@expected, "Looking for $regex in multiple files with grouping" );
+}
+
+# see https://github.com/petdance/ack2/issues/326 and links there for details
+WITH_COLUMNS_AND_CONTEXT: {
+    my @files = qw( t/text/freedom-of-choice.txt );
+    my @expected = split( /\n/, <<"EOF" );
+$files[0]-2-Nobody ever said life was free
+$files[0]-3-Sink, swim, go down with the ship
+$files[0]:4:15:But use your freedom of choice
+$files[0]-5-
+$files[0]-6-I'll say it again in the land of the free
+$files[0]:7:11:Use your freedom of choice
+$files[0]:8:7:Your freedom of choice
+$files[0]-9-
+$files[0]-10-In ancient Rome
+--
+$files[0]-17-He dropped dead
+$files[0]-18-
+$files[0]:19:2:Freedom of choice
+$files[0]-20-Is what you got
+$files[0]:21:2:Freedom of choice!
+$files[0]-22-
+$files[0]-23-Then if you've got it, you don't want it
+--
+$files[0]-27-
+$files[0]-28-I'll say it again in the land of the free
+$files[0]:29:11:Use your freedom of choice
+$files[0]:30:2:Freedom of choice
+$files[0]-31-
+$files[0]:32:2:Freedom of choice
+$files[0]-33-Is what you got
+$files[0]:34:2:Freedom of choice!
+$files[0]-35-
+$files[0]-36-In ancient Rome
+--
+$files[0]-43-He dropped dead
+$files[0]-44-
+$files[0]:45:2:Freedom of choice
+$files[0]-46-Is what you got
+$files[0]:47:2:Freedom from choice
+$files[0]-48-Is what you want
+$files[0]-49-
+$files[0]:50:10:    -- "Freedom Of Choice", Devo
+EOF
+
+    my $regex = 'reedom';
+    my @args = ( '--column', '-C2', '-H', $regex );
+
+    ack_lists_match( [ @args, @files ], \@expected, "Looking for $regex in file $files[0] with columns and context" );
 }


### PR DESCRIPTION
Test included.

Discussion: currently using options --column and -C <number> together results in warnings and adding column position even when there is no match in line (for preceding context). For example:

```
$ ./tack --column -C 2 'Freedom of choice!' t/text/
t/text/freedom-of-choice.txt
19-1-Freedom of choice
20-1-Is what you got
21:1:Freedom of choice!
Use of uninitialized value $line_parts[1] in join or string at blib/script/ack line 569, <__ANONIO__> line 21.
22--
Use of uninitialized value $line_parts[1] in join or string at blib/script/ack line 569, <__ANONIO__> line 21.
23--Then if you've got it, you don't want it
--
32-1-Freedom of choice
33-1-Is what you got
34:1:Freedom of choice!
Use of uninitialized value $line_parts[1] in join or string at blib/script/ack line 569, <__ANONIO__> line 34.
35--
Use of uninitialized value $line_parts[1] in join or string at blib/script/ack line 569, <__ANONIO__> line 34.
36--In ancient Rome
```

This patch fixes this. After applying this patch the result is:

```
$ ./tack --column -C 2 'Freedom of choice!' t/text/
t/text/freedom-of-choice.txt
19-Freedom of choice
20-Is what you got
21:1:Freedom of choice!
22-
23-Then if you've got it, you don't want it
--
32-Freedom of choice
33-Is what you got
34:1:Freedom of choice!
35-
36-In ancient Rome
```
