### PR TITLE
ignore Cabal sandbox directories by default

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -90,6 +90,9 @@ sub _options_block {
 # Eclipse workspace folder
 --ignore-directory=is:.metadata
 
+# Cabal (Haskell) sandboxes
+--ignore-directory=is:.cabal-sandbox
+
 ### Files to ignore
 
 # Backup files

--- a/t/ack-dump.t
+++ b/t/ack-dump.t
@@ -32,5 +32,5 @@ DUMP: {
     is( scalar @perl, 2, 'Two specs for Perl' );
 
     my @ignore_dir = grep { /ignore-dir/ } @results;
-    is( scalar @ignore_dir, 23, 'Twenty-three specs for ignoring directories' );
+    is( scalar @ignore_dir, 24, 'Twenty-four specs for ignoring directories' );
 }


### PR DESCRIPTION
Cabal sandboxes are sandbox environments for Haskell packages,
containing compiled packages and a bunch of metadata that users of
ack are unlikely to want to search.  Therefore ignore .cabal-sandbox
directories by default.

---

I sent the patch to ack-users@googlegroups.com as the manpage requests, but
it doesn't seems to have made it through yet.  I don't have a Google account so
hopefully it shows up...
