### PR TITLE
man.t: strip ansi escape codes

### DIFF
--- a/xt/man.t
+++ b/xt/man.t
@@ -11,6 +11,7 @@ sub strip_special_chars {
     my ( $s ) = @_;
 
     $s =~ s/.[\b]//g;
+    $s =~ s/\e\[?.*?[\@-~]//g;
 
     return $s;
 }


### PR DESCRIPTION
On FreeBSD the `ack --man` output read by man.t contains ANSI escape
codes, which breaks the test.  Update strip_special_chars to also
strip ANSI escape codes, fixing the test on FreeBSD.
