### PR TITLE
windows_slashify assigns, does not return a regex

### DIFF
--- a/t/ack-g.t
+++ b/t/ack-g.t
@@ -261,7 +261,7 @@ t/(text)/science-of-myth.txt
 t/(text)/shut-up-be-happy.txt
 END_COLOR
 
-    $expected_original =~ windows_slashify( $expected_original ) if is_windows;
+    $expected_original = windows_slashify( $expected_original ) if is_windows;
 
     my @expected   = colorize( $expected_original );
 

--- a/t/highlighting.t
+++ b/t/highlighting.t
@@ -23,7 +23,7 @@ BASIC: {
 {19}:When she was raped and cut up, left for dead in her trunk, her (beliefs) held true
 END
 
-    $expected_original =~ windows_slashify( $expected_original ) if is_windows;
+    $expected_original = windows_slashify( $expected_original ) if is_windows;
 
     my @expected = colorize( $expected_original );
 
@@ -47,7 +47,7 @@ METACHARACTERS: {
 {14}:In fact, for better (understanding) we take the facts of science and apply them
 END
 
-    $expected_original =~ windows_slashify( $expected_original ) if is_windows;
+    $expected_original = windows_slashify( $expected_original ) if is_windows;
 
     my @expected = colorize( $expected_original );
 
@@ -72,7 +72,7 @@ CONTEXT: {
 {6}-Shut up.
 END
 
-    $expected_original =~ windows_slashify( $expected_original ) if is_windows;
+    $expected_original = windows_slashify( $expected_original ) if is_windows;
 
     my @expected = colorize( $expected_original );
 


### PR DESCRIPTION
Looks like a typo in 5fa7b3a9ad93ad69405a7159da43d541dcb73d65 causes some tests to fail.
