### PR TITLE
make: add Makefile.Debug and Makefile.Release

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -166,7 +166,8 @@ sub _options_block {
 --type-add=make:ext:mak
 --type-add=make:is:makefile
 --type-add=make:is:Makefile
---type-add=make:is:GNUmakefile
+--type-add=make:is:Makefile.Debug
+--type-add=make:is:Makefile.Release
 
 # Rakefiles
 # http://rake.rubyforge.org/


### PR DESCRIPTION
.. instead of makefile Makefile GNUmakefile

This generalises Makefile detection with a regex. I needed this because Qt Project creates Makefile.Debug and Makefile.Release, and I think it makes ack more useful out-of-the-box for Qt developers.
