### PR TITLE
Added documentation on available colors; fixes #26

### DIFF
--- a/ack
+++ b/ack
@@ -1673,6 +1673,27 @@ If you are not on Windows, you never need to use C<ACK_PAGER_COLOR>.
 
 =back
 
+=head1 AVAILABLE COLORS
+
+F<ack> uses the colors available in Perl's L<Term::ANSIColor> module, which
+provides the following listed values. Note that case does not matter when using
+these values.
+
+=head2 Foreground colors
+
+black  red  green  yellow  blue  magenta  cyan  white
+
+bright_black  bright_red      bright_green  bright_yellow
+bright_blue   bright_magenta  bright_cyan   bright_white
+
+=head2 Background colors
+
+on_black  on_red      on_green  on_yellow
+on_blue   on_magenta  on_cyan   on_white
+
+on_bright_black  on_bright_red      on_bright_green  on_bright_yellow
+on_bright_blue   on_bright_magenta  on_bright_cyan   on_bright_white
+
 =head1 ACK & OTHER TOOLS
 
 =head2 Vim integration


### PR DESCRIPTION
I added a documentation block to explain the colors available in ack. This information was pulled directly from the [Stack Overflow answer](http://stackoverflow.com/questions/9625316/what-color-options-exist-for-ack-grep-for-colorization-of-output-logs-etc/9626444#9626444) that detailed the available options.

If this is the wrong place to put it, let me know.
