### PR TITLE
Fixing indentation levels for color values

### DIFF
--- a/ack
+++ b/ack
@@ -1681,18 +1681,18 @@ these values.
 
 =head2 Foreground colors
 
-black  red  green  yellow  blue  magenta  cyan  white
+    black  red  green  yellow  blue  magenta  cyan  white
 
-bright_black  bright_red      bright_green  bright_yellow
-bright_blue   bright_magenta  bright_cyan   bright_white
+    bright_black  bright_red      bright_green  bright_yellow
+    bright_blue   bright_magenta  bright_cyan   bright_white
 
 =head2 Background colors
 
-on_black  on_red      on_green  on_yellow
-on_blue   on_magenta  on_cyan   on_white
+    on_black  on_red      on_green  on_yellow
+    on_blue   on_magenta  on_cyan   on_white
 
-on_bright_black  on_bright_red      on_bright_green  on_bright_yellow
-on_bright_blue   on_bright_magenta  on_bright_cyan   on_bright_white
+    on_bright_black  on_bright_red      on_bright_green  on_bright_yellow
+    on_bright_blue   on_bright_magenta  on_bright_cyan   on_bright_white
 
 =head1 ACK & OTHER TOOLS
 


### PR DESCRIPTION
I've tweaked the indentation for the color values in the documentation (for issue #26).
