### PR TITLE
Clear $ENV{ACKRC} in t/config-finder.t

### DIFF
--- a/t/config-finder.t
+++ b/t/config-finder.t
@@ -31,6 +31,9 @@ plan tests => 26;
 # Set HOME to a known value, so we get predictable results:
 $ENV{'HOME'} = realpath('t/home');
 
+# Clear the users ACKRC so it doesn't throw out expect_ackrcs().
+delete $ENV{'ACKRC'};
+
 sub touch_ackrc {
     my $filename = shift || '.ackrc';
     write_file( $filename, () );


### PR DESCRIPTION
If the user already has an $ACKRC set, t/config-finder.t fails.

To repro:
    touch /tmp/ackrc ; ACKRC=/tmp/ackrc make test
