### PR TITLE
Hopefully final fix to gh #419 - config-finder.t

### DIFF
--- a/t/config-finder.t
+++ b/t/config-finder.t
@@ -249,5 +249,5 @@ do {
     unlink $ackrc->filename;
 };
 
-clean_up_globals();
 chdir $wd;
+clean_up_globals();


### PR DESCRIPTION
Fixes the error message below. At this point, all tests pass for me.

```
t/config-finder.t ............ 1/26 Insecure dependency in unlink while running
with -T switch at t/config-finder.t line 67.
cannot remove path when cwd is C:/temp/MNBE33EDmf/foo for C:/temp/MNBE33EDmf:  a
t C:/strawberry/perl/lib/File/Temp.pm line 1616.
# Looks like your test exited with 255 just after 26.
```
