### PR TITLE
Reworked context handling to be faster

### DIFF
--- a/ack
+++ b/ack
@@ -47,6 +47,8 @@ our $opt_L;
 our $opt_l;
 our $opt_passthru;
 our $opt_column;
+# flag if we need any context tracking
+our $is_tracking_context;
 
 # These are all our globals.
 
@@ -359,9 +361,6 @@ sub build_regex {
 my $match_column_number;
 
 {
-
-# flag if we need any context tracking
-my $is_tracking_context;
 
 # number of context lines
 my $n_before_ctx_lines;
@@ -1023,7 +1022,9 @@ sub main {
 
 RESOURCES:
     while ( my $resource = $resources->next ) {
-        setup_line_context_for_file($opt);
+        if ($is_tracking_context) {
+            setup_line_context_for_file($opt);
+        }
 
         # XXX Combine the -f and -g functions
         if ( $opt_f ) {
@@ -1076,7 +1077,7 @@ RESOURCES:
                 elsif ( $opt_passthru ) {
                     print_line_with_options($opt, $filename, $_, $., ':');
                 }
-                else {
+                elsif ( $is_tracking_context ) {
                     print_line_if_context($opt, $filename, $_, $., '-');
                 }
                 return 1;


### PR DESCRIPTION
I did some changes to the context handling in ack to speed up searches with `-A`, `-B` and `-C` (see #487):
- lines for the "after" context are not saved in an array to print out later, but are printed out directly while iterating over the file
- lines for the "before" context are kept in a fixed size array, not pushed and shifted changing the array size all the time

Additionally I moved most of the context handling logic into a few specialized functions, `setup_line_context()`, `setup_line_context_for_file()` and `print_line_if_context()`, making the rest of the code simpler.

The diff is larger than I'd like, but the resulting code should be clearer and easier to understand. The tests pass. Speed, while not yet optimal, is significantly improved:

```
                                           |   1.96 |   2.12 |   2.14 |   HEAD
------------------------------------------------------------------------------
            ack int /home/sth/work/devices |   1.25 |   1.47 |   0.86 |   0.88
    ack std::vector /home/sth/work/devices |   0.50 |   1.20 |   0.37 |   0.34
         ack xyxyxy /home/sth/work/devices |   0.46 |   1.23 |   0.37 |   0.35
        ack int -A3 /home/sth/work/devices |   1.71 |   3.48 |   3.02 |   2.18
ack std::vector -A3 /home/sth/work/devices |   0.56 |   2.80 |   2.51 |   1.78
     ack xyxyxy -A3 /home/sth/work/devices |   0.49 |   2.90 |   2.53 |   1.78
        ack int -B3 /home/sth/work/devices |   2.03 |   3.79 |   3.28 |   2.50
ack std::vector -B3 /home/sth/work/devices |   0.74 |   2.98 |   2.75 |   2.11
     ack xyxyxy -B3 /home/sth/work/devices |   0.65 |   3.14 |   2.77 |   2.15
        ack int -C1 /home/sth/work/devices |   1.94 |   4.14 |   3.62 |   2.38
ack std::vector -C1 /home/sth/work/devices |   0.70 |   3.36 |   3.21 |   2.10
     ack xyxyxy -C1 /home/sth/work/devices |   0.67 |   3.52 |   3.16 |   1.97
        ack int -C5 /home/sth/work/devices |   2.41 |   4.47 |   3.98 |   2.67
ack std::vector -C5 /home/sth/work/devices |   0.73 |   3.34 |   3.14 |   2.18
     ack xyxyxy -C5 /home/sth/work/devices |   0.67 |   3.41 |   3.04 |   2.07
```

(In this table `2.14` is the current head of the `dev` branch)
