### PR TITLE
Support Multiple, Newline-Separated Patterns

### DIFF
--- a/t/split-newline.t
+++ b/t/split-newline.t
@@ -1,0 +1,82 @@
+#!perl -T
+
+use strict;
+use warnings;
+use lib 't';
+
+use File::Next;
+use Util;
+use Test::More tests => 12;
+
+prep_environment();
+
+SINGLE_STRING: {
+    my @expected = split( /\n/, <<'EOF' );
+One day up near Salinas, Lord, I let her slip away
+EOF
+
+    my @files = qw( t/text/me-and-bobbie-mcgee.txt );
+    my @results = run_ack( "Salinas", @files );
+
+    lists_match( \@results, \@expected, 'A single string pattern' );
+}
+
+SINGLE_REGEX: {
+    my @expected = split( /\n/, <<'EOF' );
+From the Kentucky coal mines to the California sun
+Bobbie baby kept me from the cold
+EOF
+
+    my @files = qw( t/text/me-and-bobbie-mcgee.txt );
+    my @results = run_ack( "co(?:ld|al)", @files );
+
+    lists_match( \@results, \@expected, 'A single pattern' );
+}
+
+SINGLE_QUOTED_REGEX: {
+    my @expected = split( /\n/, <<'EOF' );
+EOF
+
+    my @files = qw( t/text/me-and-bobbie-mcgee.txt );
+    my @results = run_ack( "-Q", "co(?:ld|al)", @files );
+
+    lists_match( \@results, \@expected, 'A single quoted pattern (no match)' );
+}
+
+MULTIPLE_STRINGS: {
+    my @expected = split( /\n/, <<'EOF' );
+From the Kentucky coal mines to the California sun
+One day up near Salinas, Lord, I let her slip away
+EOF
+
+    my @files = qw( t/text/me-and-bobbie-mcgee.txt );
+    my @results = run_ack( "Salinas\nKentucky", @files );
+
+    lists_match( \@results, \@expected, 'Multiple strings' );
+}
+
+MULTIPLE_REGEXES: {
+    my @expected = split( /\n/, <<'EOF' );
+I was playin' soft while Bobbie sang the blues
+From the Kentucky coal mines to the California sun
+Bobbie shared the secrets of my soul
+Bobbie baby kept me from the cold
+One day up near Salinas, Lord, I let her slip away
+EOF
+
+    my @files = qw( t/text/me-and-bobbie-mcgee.txt );
+    my @results = run_ack( "co(?:ld|al)\nso(?:ft|ul)\nSalinas", @files );
+
+    lists_match( \@results, \@expected, 'Multiple regexes' );
+}
+
+MULTIPLE_QUOTED_REGEXES: {
+    my @expected = split( /\n/, <<'EOF' );
+One day up near Salinas, Lord, I let her slip away
+EOF
+
+    my @files = qw( t/text/me-and-bobbie-mcgee.txt );
+    my @results = run_ack( "-Q", "co(?:ld|al)\nso(?:ft|ul)\nSalinas", @files );
+
+    lists_match( \@results, \@expected, 'Multiple quoted regexes' );
+}


### PR DESCRIPTION
Per [POSIX 1003.1](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html#tag_20_55):

> The *pattern_list*'s value shall consist of one or more patterns separated by `<newline>` characters

So, for example, you could do:

```
bash%  ls -l /etc/ | grep $'passwd\ngroup'
```

Now you can do the same with `ack`:

```
bash% ls -l /etc/ | ack $'passwd\ngroup`
bash% ls -l /etc/ | ack $'p(asswd|rofile)\ns(hells|udoers)'
```

This is especially handy with command substitution [backticks], as it means you don't have to manually perform any `alice|bob|carol` shenanigans; the alternation is automatically performed *for* you:

```
bash% ack /etc --match "`/bin/ls /home/`" 
```