### PR TITLE
Ensure that tempdirs are removed in Perl 5.28.

### DIFF
--- a/t/ack-s.t
+++ b/t/ack-s.t
@@ -46,5 +46,6 @@ WITH_RESTRICTED_DIR: {
 
     is_empty_array( $stderr );
 
+    chmod 0755, 'foo', 'baz';
     chdir $wd;
 }


### PR DESCRIPTION
File::Temp::tempdir() internally calls File::Path::rmtree() to implement the
'CLEANUP => 1' option.  A security vulnernability was discovered in rmtree()
in early 2017.  This vulnerability has been addressed in File::Path versions
2.14 and later; a thus patched version of File::Path will appear in Perl-5.28
to be released in spring 2018.

The security correction changes the functionality of rmtree() when not called
with a true value as its third positional argument:

    rmtree($my_tempdir, 0, 0);

As of File::Path 2.14, this syntax will no longer remove directories for which
the user lacks both 'read' and 'execute' permissions.  For example, any
directory whose numerical permissions are octal 0000 or 0200 will no longer be
deleted.

The file for which this patch is being submitted contains a chmod() call with
0000 permissions.  While, even if this patch is not applied, all tests in the
file will continue to PASS, the 0000 directories will not be deleted and the
person running the test will be shown warnings that some directories have not
been deleted.  The patch attached addresses this situation by restoring owner
'read' and 'execute' permissions to the directory before the call to tempdir()
goes out of scope.  This will once again remove the tempdirs, eliminate the
warnings and avert user confusion.