### PR TITLE
Use File::Temp instead of "stdout.log" and "stderr.log" in run_cmd()

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -289,8 +289,10 @@ sub run_cmd {
     if ( is_windows() ) {
         require Win32::ShellQuote;
         # Capture stderr & stdout output into these files (only on Win32).
-        my $catchout_file = 'stdout.log';
-        my $catcherr_file = 'stderr.log';
+        my $catchout = File::Temp->new;
+        my $catcherr = File::Temp->new;
+        my $catchout_file = $catchout->filename;
+        my $catcherr_file = $catcherr->filename;
 
         open(SAVEOUT, ">&STDOUT") or die "Can't dup STDOUT: $!";
         open(SAVEERR, ">&STDERR") or die "Can't dup STDERR: $!";


### PR DESCRIPTION
For #61.

Another bug is that t/zero.t will chdir to t/swamp and run_cmd() will create t/swamp/stdout.log and t/swamp/stderr.log.  These extra files in t/swamp will cause subsequent tests with ack-standalone to fail.